### PR TITLE
Fix path to Lua scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,4 +318,4 @@ Please find a list of frequently asked questions and their respective answers at
 ## Contributing
 
 Contributions are welcome!
-Please see `src/scripts/examples/*.lua` directory for Lua scripting examples.
+Please see `eruption/src/scripts/examples/*.lua` directory for Lua scripting examples.


### PR DESCRIPTION
The path `src/scripts/examples/*.lua` implies the `src` directory is located in the root of the project when its actually inside the `eruption` directory.