### PR TITLE
Allow users to configure the duration of the brightness fade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ build:
 
 	@echo ""
 	@echo "Now please run 'sudo make install' to install Eruption"
+	@echo ""
+	@echo "If Eruption is already running, stop it first.  Hints:"
+	@echo "systemctl --user stop eruption-audio-proxy.service"
+	@echo "systemctl --user stop eruption-process-monitor.service"
+	@echo "systemctl stop eruption.service"
 
 start:
 	@echo "Notifying system daemons about Eruption..."

--- a/eruption/src/constants.rs
+++ b/eruption/src/constants.rs
@@ -76,8 +76,8 @@ pub const PROCESS_SPAWN_WAIT_MILLIS: u64 = 800;
 /// Target frames per second
 pub const TARGET_FPS: u64 = 24;
 
-/// Fade in on profile switch for n frames
-pub const FADE_FRAMES: u64 = 32;
+/// Fade in on profile switch for n milliseconds
+pub const FADE_MILLIS: u64 = 1333;
 
 /// The number of "pixels" on the canvas
 pub const CANVAS_SIZE: usize = 144 + 36;

--- a/eruption/src/main.rs
+++ b/eruption/src/main.rs
@@ -200,9 +200,12 @@ lazy_static! {
     /// Global "keyboard brightness" modifier
     pub static ref BRIGHTNESS: AtomicIsize = AtomicIsize::new(100);
 
-    /// Global "keyboard brightness" modifier
+    /// Global modifier when fading into a profile
     pub static ref BRIGHTNESS_FADER: AtomicIsize = AtomicIsize::new(0);
-
+    
+    /// Global modifier to compare fading into a profile
+    pub static ref BRIGHTNESS_FADER_BASE: AtomicIsize = AtomicIsize::new(0);
+    
     /// AFK timer
     pub static ref LAST_INPUT_TIME: Arc<Mutex<Instant>> = Arc::new(Mutex::new(Instant::now()));
 
@@ -608,7 +611,15 @@ pub fn switch_profile(
                 // everything is fine, finally assign the globally active profile
                 debug!("Switch successful");
 
-                crate::BRIGHTNESS_FADER.store(constants::FADE_FRAMES as isize, Ordering::SeqCst);
+                let fade_millis = crate::CONFIG
+                    .lock()
+                    .as_ref()
+                    .unwrap()
+                    .get_int("global.profile_fade_milliseconds")
+                    .unwrap_or(constants::FADE_MILLIS as i64);
+                let fade_frames = (fade_millis * constants::TARGET_FPS as i64 / 1000) as isize;
+                crate::BRIGHTNESS_FADER.store(fade_frames, Ordering::SeqCst);
+                crate::BRIGHTNESS_FADER_BASE.store(fade_frames, Ordering::SeqCst);
 
                 *ACTIVE_PROFILE.lock() = Some(profile);
 
@@ -1019,7 +1030,7 @@ fn run_main_loop(
         }
 
         // compute AFK time
-        let afk_timeout_secs = CONFIG
+        let afk_timeout_secs = crate::CONFIG
             .lock()
             .as_ref()
             .unwrap()

--- a/eruption/src/scripting/script.rs
+++ b/eruption/src/scripting/script.rs
@@ -980,10 +980,16 @@ pub fn run_script(
                             if LOCAL_LED_MAP_MODIFIED.with(|f| *f.borrow()) {
                                 LOCAL_LED_MAP.with(|foreground| {
                                     let brightness = crate::BRIGHTNESS.load(Ordering::SeqCst);
+                                    
                                     let fader = crate::BRIGHTNESS_FADER.load(Ordering::SeqCst);
+                                    let fader_base = crate::BRIGHTNESS_FADER_BASE.load(Ordering::SeqCst);
 
-                                    let brightness = (1.0 - (fader as f32 / constants::FADE_FRAMES as f32)) * brightness as f32;
-
+                                    let brightness = if fader_base > 0 && fader > 0 {
+                                        (1.0 - (fader as f32 / fader_base as f32)) * brightness as f32
+                                    } else {
+                                        brightness as f32
+                                    };
+                                    
                                     for chunks in LED_MAP.write().chunks_exact_mut(constants::CANVAS_SIZE) {
                                         for (idx, background) in chunks.iter_mut().enumerate() {
                                             let bg = &background;

--- a/support/config/eruption.conf
+++ b/support/config/eruption.conf
@@ -20,6 +20,9 @@ grab_mouse = true
 afk_profile = "/var/lib/eruption/profiles/rainbow-wave.profile"
 afk_timeout_secs = 0
 
+# Fade duration when switching profiles
+profile_fade_milliseconds = 1333
+
 # [[devices]]
 # entry_type = "device"
 # device_class = "serial"


### PR DESCRIPTION
This creates a new profile_fade_milliseconds configuration entry and uses that to control the brightness fade rather than a constant 32 frames. 

My motivation for this is because I switch profiles using eruption-process-monitor and I want the switched profile to be applied immediately.

I know next to nothing about Rust so I might have some dumb or superfluous code. 