### PR TITLE
Modify eruptionctl to work better with profiles and scripts outside the system-wide profiles and scripts directory.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
  "paste 1.0.9",
  "pretty_assertions",
  "rust-embed",
+ "same-file",
  "serde",
  "serde_json",
  "thiserror",

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ build:
 
 	@echo ""
 	@echo "Now please run 'sudo make install' to install Eruption"
+	@echo ""
+	@echo "If Eruption is already running, stop it first.  Consider:"
+	@echo "make stop && sudo make install && make start"
 
 start:
 	@echo "Notifying system daemons about Eruption..."

--- a/eruptionctl/Cargo.toml
+++ b/eruptionctl/Cargo.toml
@@ -62,6 +62,7 @@ i18n-embed-fl = "0.6.4"
 rust-embed = "6.4.0"
 unic-langid = "0.9.0"
 icecream = "0.1.0"
+same-file = "1"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"


### PR DESCRIPTION
When specifying a profile using `switch profile`, `profile edit`, or `profile info`, if the given argument is a filepath, use that file as the profile file rather than looking it up in the system profiles directory.

In `scripts edit` and `scripts info`, allow the script argument to be either the script's self-described name (as it was before) or the script's filename.  As with the profile argument changes, if the script argument is a filepath, load that file, otherwise look up the name from the system scripts directory.

The bulk of the code changes are to the `param` command.  Previously, specifying a script would look it up in the scripts directory, then check if the script is also listed in the active profile's scripts.  Now, it just goes straight for the active profile's scripts. This also works when the profile specifies scripts outside of the system scripts directory.  As with the `scripts` command, you can specify the script by the script's self-described name or by its filename.  By sharing profile and script lookups with the `param` command variants, a lot of code can be cleaned up.

Ultimately, I wonder if this approach to discovering parameters would be better off being replaced by exposing the active script's parameters via dbus, rather than rummaging through files.  But that can be code for another day.

Also, remove the `id` field of Manifest, as it wasn't used anywhere, and its meaning becomes ambiguous when working with scripts outside the system scripts directory.

PS, same disclaimer as the other PR - I'm new to Rust and so some of this code might not be idiomatic.  But it does run as intended, at least.  Also, I realized the other day that the makefile already has targets in place to stop the systemd units, so I've updated the hint.  But in order to make the two PRs distinct, that means it will cause a minor merge conflict. 