### PR TITLE
Unify parameter handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,4 +284,7 @@ check:
 clean:
 	@cargo clean
 
-.PHONY: check clean all start stop install uninstall build
+test:
+	@cargo test
+
+.PHONY: check clean all start stop install uninstall build test

--- a/eruption-gui/src/main.rs
+++ b/eruption-gui/src/main.rs
@@ -49,9 +49,9 @@ mod constants;
 mod dbus_client;
 mod device;
 mod error_log;
-mod manifest;
 mod preferences;
 mod profiles;
+mod scripting;
 mod ui;
 mod util;
 

--- a/eruption-gui/src/manifest.rs
+++ b/eruption-gui/src/manifest.rs
@@ -1,1 +1,0 @@
-../../eruption/src/scripting/manifest.rs

--- a/eruption-gui/src/scripting/manifest.rs
+++ b/eruption-gui/src/scripting/manifest.rs
@@ -1,0 +1,1 @@
+../../../eruption/src/scripting/manifest.rs

--- a/eruption-gui/src/scripting/mod.rs
+++ b/eruption-gui/src/scripting/mod.rs
@@ -17,9 +17,5 @@
     Copyright (c) 2019-2022, The Eruption Development Team
 */
 
-pub mod callbacks;
-pub mod constants;
 pub mod manifest;
 pub mod parameters;
-pub mod parameters_util;
-pub mod script;

--- a/eruption-gui/src/scripting/parameters.rs
+++ b/eruption-gui/src/scripting/parameters.rs
@@ -1,0 +1,1 @@
+../../../eruption/src/scripting/parameters.rs

--- a/eruption-gui/src/ui/profiles.rs
+++ b/eruption-gui/src/ui/profiles.rs
@@ -17,9 +17,14 @@
     Copyright (c) 2019-2022, The Eruption Development Team
 */
 
-use crate::scripting::parameters::{ManifestValue, TypedValue};
-use crate::{dbus_client, profiles::FindConfig};
-use crate::{profiles::Profile, scripting::manifest::Manifest, scripting::parameters, util};
+use crate::{
+    dbus_client,
+    profiles::Profile,
+    scripting::manifest::Manifest,
+    scripting::parameters::{self, ManifestValue, TypedValue},
+    util,
+};
+
 use glib::clone;
 use glib::IsA;
 use gtk::builders::{
@@ -744,18 +749,9 @@ fn populate_visual_config_editor<P: AsRef<Path>>(builder: &Builder, profile: P) 
         container.pack_start(&expander, false, false, 8);
 
         if let Some(params) = &manifest.config {
+            let profile_script_parameters = profile.config.get_parameters(&manifest.name);
             for param in params {
-                let name = &param.name;
-
-                let value = if let Some(ref values) = profile.config {
-                    match values.get(name) {
-                        Some(e) => e.find_config_param(name),
-
-                        None => None,
-                    }
-                } else {
-                    None
-                };
+                let value = profile_script_parameters.and_then(|p| p.get_parameter(&param.name));
 
                 let child = create_config_editor(&profile, &manifest, param, &value)?;
                 expander_container.pack_start(&child, false, true, 0);

--- a/eruption-gui/src/ui/profiles.rs
+++ b/eruption-gui/src/ui/profiles.rs
@@ -19,10 +19,11 @@
 
 use crate::{dbus_client, profiles::FindConfig};
 use crate::{
-    manifest,
-    profiles::{self, Profile},
+    profiles::Profile,
+    scripting::manifest::{self, Manifest},
+    scripting::parameters,
+    util,
 };
-use crate::{manifest::Manifest, util};
 use glib::clone;
 use glib::IsA;
 use gtk::builders::{
@@ -588,7 +589,7 @@ fn create_config_editor(
     profile: &Profile,
     script: &Manifest,
     param: &manifest::ConfigParam,
-    value: &Option<&profiles::ConfigParam>,
+    value: &Option<&parameters::ProfileParameter>,
 ) -> Result<Frame> {
     fn parameter_changed<T>(profile: &Profile, script: &Manifest, name: &str, value: T)
     where
@@ -627,7 +628,10 @@ fn create_config_editor(
         } => {
             let value = if let Some(value) = value {
                 match value {
-                    profiles::ConfigParam::Int { name: _, value, .. } => *value,
+                    parameters::ProfileParameter {
+                        value: parameters::TypedValue::Int(value),
+                        ..
+                    } => *value,
 
                     _ => return Err(ProfilesError::TypeMismatch {}.into()),
                 }
@@ -671,7 +675,10 @@ fn create_config_editor(
         } => {
             let value = if let Some(value) = value {
                 match value {
-                    profiles::ConfigParam::Float { name: _, value, .. } => *value,
+                    parameters::ProfileParameter {
+                        value: parameters::TypedValue::Float(value),
+                        ..
+                    } => *value,
 
                     _ => return Err(ProfilesError::TypeMismatch {}.into()),
                 }
@@ -713,7 +720,10 @@ fn create_config_editor(
         } => {
             let value = if let Some(value) = value {
                 match value {
-                    profiles::ConfigParam::Bool { name: _, value, .. } => *value,
+                    parameters::ProfileParameter {
+                        value: parameters::TypedValue::Bool(value),
+                        ..
+                    } => *value,
 
                     _ => return Err(ProfilesError::TypeMismatch {}.into()),
                 }
@@ -753,7 +763,10 @@ fn create_config_editor(
         } => {
             let value = if let Some(value) = *value {
                 match value {
-                    profiles::ConfigParam::String { name: _, value, .. } => value.clone(),
+                    parameters::ProfileParameter {
+                        value: parameters::TypedValue::String(value),
+                        ..
+                    } => value.clone(),
 
                     _ => return Err(ProfilesError::TypeMismatch {}.into()),
                 }
@@ -796,7 +809,10 @@ fn create_config_editor(
         } => {
             let value = if let Some(value) = value {
                 match value {
-                    profiles::ConfigParam::Color { name: _, value, .. } => *value,
+                    parameters::ProfileParameter {
+                        value: parameters::TypedValue::Color(value),
+                        ..
+                    } => *value,
 
                     _ => return Err(ProfilesError::TypeMismatch {}.into()),
                 }

--- a/eruption-gui/src/util.rs
+++ b/eruption-gui/src/util.rs
@@ -17,25 +17,25 @@
     Copyright (c) 2019-2022, The Eruption Development Team
 */
 
-// use crate::manifest;
-use crate::{constants, dbus_client, preferences, profiles, scripting::manifest};
+use crate::{constants, dbus_client, preferences, profiles};
 use byteorder::{ByteOrder, LittleEndian};
 use dbus::blocking::stdintf::org_freedesktop_dbus::Properties;
 use dbus::blocking::Connection;
-// use manifest::Manifest;
-// use std::fs;
-use crate::scripting::manifest::ManifestError;
 use lazy_static::lazy_static;
+use log::warn;
 use parking_lot::Mutex;
-use std::collections::HashMap;
-use std::u8;
-use std::{convert::TryFrom, process::Command};
 use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    fs,
     path::{Path, PathBuf},
     process::Child,
+    process::Command,
     sync::Arc,
+    thread,
+    time::Duration,
+    u8,
 };
-use std::{thread, time::Duration};
 
 type Result<T> = std::result::Result<T, eyre::Error>;
 
@@ -50,6 +50,19 @@ pub enum UtilError {
 
     #[error("Daemon restart failed")]
     RestartFailed,
+
+    #[error("File not found: {description}")]
+    FileNotFound { description: String },
+
+    #[error("Read failed: {description}")]
+    FileReadError {
+        #[source]
+        source: std::io::Error,
+        description: String,
+    },
+
+    #[error("Not a file")]
+    NotAFile {},
     // #[error("Unknown error: {description}")]
     // UnknownError { description: String },
 }
@@ -442,7 +455,7 @@ pub fn get_script_dirs() -> Vec<PathBuf> {
 
     // if we could not determine a valid set of paths, use a hard coded fallback instead
     if result.is_empty() {
-        log::warn!("Using default fallback script directory");
+        warn!("Using default fallback script directory");
 
         let path = PathBuf::from(constants::DEFAULT_SCRIPT_DIR);
         result.push(path);
@@ -452,16 +465,71 @@ pub fn get_script_dirs() -> Vec<PathBuf> {
 }
 
 /// Returns the absolute path of a script file
-pub fn match_script_file(script: &Path) -> Result<PathBuf> {
-    let scripts = manifest::get_script_files()?;
+pub fn match_script_path<P: AsRef<Path>>(script_file: &P) -> Result<PathBuf> {
+    let script_file = script_file.as_ref();
 
-    for f in scripts {
-        if f.file_name().unwrap_or_default() == script {
-            return Ok(f);
+    for dir in get_script_dirs().iter() {
+        let script_path = dir.join(script_file);
+
+        if let Ok(metadata) = fs::metadata(&script_path) {
+            if metadata.is_file() {
+                return Ok(script_path.canonicalize()?);
+            }
         }
     }
 
-    Err(ManifestError::ScriptEnumerationError {}.into())
+    Err(UtilError::FileNotFound {
+        description: format!(
+            "Could not find file in search path(s): {}",
+            &script_file.display()
+        ),
+    }
+    .into())
+}
+
+pub fn demand_file_is_accessible<P: AsRef<Path>>(p: P) -> Result<()> {
+    // Does the path exist?
+    let path = match fs::canonicalize(p) {
+        Ok(path) => path,
+        Err(e) => {
+            return Err(UtilError::FileReadError {
+                source: e,
+                description: "Could not find file".to_owned(),
+            }
+            .into())
+        }
+    };
+
+    // Is the metadata readable?
+    let metadata = match fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(e) => {
+            return Err(UtilError::FileReadError {
+                source: e,
+                description: "Could not read metadata".to_owned(),
+            }
+            .into())
+        }
+    };
+
+    // Is the path a regular file?  (Symlinks will have been canonicalized to regular files.)
+    if !metadata.is_file() {
+        return Err(UtilError::NotAFile {}.into());
+    }
+
+    // Is the file readable?
+    match fs::File::open(&path) {
+        Err(e) => {
+            return Err(UtilError::FileReadError {
+                source: e,
+                description: "Could not open file".to_owned(),
+            }
+            .into())
+        }
+        _ => {}
+    };
+
+    Ok(())
 }
 
 pub fn enumerate_profiles() -> Result<Vec<profiles::Profile>> {

--- a/eruption-gui/src/util.rs
+++ b/eruption-gui/src/util.rs
@@ -18,13 +18,13 @@
 */
 
 // use crate::manifest;
-use crate::{constants, dbus_client, manifest, preferences, profiles};
+use crate::{constants, dbus_client, preferences, profiles, scripting::manifest};
 use byteorder::{ByteOrder, LittleEndian};
 use dbus::blocking::stdintf::org_freedesktop_dbus::Properties;
 use dbus::blocking::Connection;
 // use manifest::Manifest;
 // use std::fs;
-use crate::manifest::ManifestError;
+use crate::scripting::manifest::ManifestError;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use std::collections::HashMap;

--- a/eruption/src/dbus_interface.rs
+++ b/eruption/src/dbus_interface.rs
@@ -1169,7 +1169,7 @@ fn apply_parameter(
     parameters_util::apply_parameters(
         profile_file,
         script_file,
-        &[parameters::UntypedParameterValue {
+        &[parameters::UntypedParameter {
             name: param_name.to_string(),
             value: value.to_string(),
         }],

--- a/eruption/src/dbus_interface.rs
+++ b/eruption/src/dbus_interface.rs
@@ -34,6 +34,7 @@ use crate::{
     plugins::{self, audio},
     profiles, script,
     scripting::parameters,
+    scripting::parameters_util,
 };
 
 /// D-Bus messages and signals that are processed by the main thread
@@ -1165,7 +1166,7 @@ fn apply_parameter(
     param_name: &str,
     value: &str,
 ) -> Result<()> {
-    parameters::apply_parameters(
+    parameters_util::apply_parameters(
         profile_file,
         script_file,
         &[parameters::UntypedParameterValue {

--- a/eruption/src/main.rs
+++ b/eruption/src/main.rs
@@ -72,8 +72,8 @@ use crate::{
     profiles::FindConfig,
     profiles::Profile,
     scripting::manifest::Manifest,
-    scripting::script::ToParameterValue,
-    scripting::script::{self, ParameterValue},
+    scripting::parameters::{ParameterValue, ToParameterValue},
+    scripting::script,
 };
 
 use crate::threads::DbusApiEvent;
@@ -732,7 +732,8 @@ fn merge_parameters(manifest: &Manifest, profile: &Profile) -> Vec<ParameterValu
                     let parameter_value = param.to_parameter_value(); // config default
                     match profile_config {
                         Some(profile_config) => profile_config
-                            .find_config_param(&parameter_value.name).map(|cp| cp.to_parameter_value())
+                            .find_config_param(&parameter_value.name)
+                            .map(|profile_parameter| profile_parameter.to_parameter_value())
                             .unwrap_or_else(|| {
                                 debug!("Parameter {} is undefined. Using defaults from script manifest.", parameter_value.name);
                                 parameter_value

--- a/eruption/src/main.rs
+++ b/eruption/src/main.rs
@@ -72,7 +72,7 @@ use crate::{
     profiles::FindConfig,
     profiles::Profile,
     scripting::manifest::Manifest,
-    scripting::parameters::{ParameterValue, ToParameterValue},
+    scripting::parameters::{PlainParameter, ToParameterValue},
     scripting::script,
 };
 
@@ -717,7 +717,7 @@ fn load_manifest_or_emit_error_messages(script_file: &PathBuf) -> Result<Manifes
     }
 }
 
-fn merge_parameters(manifest: &Manifest, profile: &Profile) -> Vec<ParameterValue> {
+fn merge_parameters(manifest: &Manifest, profile: &Profile) -> Vec<PlainParameter> {
     let profile_config = profile.config.as_ref().and_then(|c| c.get(&manifest.name));
 
     match &manifest.config {

--- a/eruption/src/main.rs
+++ b/eruption/src/main.rs
@@ -69,7 +69,6 @@ use crate::{
     hwdevices::{DeviceStatus, MaturityLevel, RGBA},
     plugins::macros,
     plugins::{sdk_support, uleds},
-    profiles::FindConfig,
     profiles::Profile,
     scripting::manifest::Manifest,
     scripting::parameters::{PlainParameter, ToParameterValue},
@@ -718,11 +717,11 @@ fn load_manifest_or_emit_error_messages(script_file: &PathBuf) -> Result<Manifes
 }
 
 fn merge_parameters(manifest: &Manifest, profile: &Profile) -> Vec<PlainParameter> {
-    let profile_config = profile.config.as_ref().and_then(|c| c.get(&manifest.name));
+    let profile_script_parameters = profile.config.get_parameters(&manifest.name);
 
     match &manifest.config {
         Some(manifest_config) => {
-            if profile_config.is_none() {
+            if profile_script_parameters.is_none() {
                 debug!("Active profile does not have {} config. Using config parameters from script manifest.", &manifest.name);
             }
 
@@ -730,9 +729,9 @@ fn merge_parameters(manifest: &Manifest, profile: &Profile) -> Vec<PlainParamete
                 .iter()
                 .map(|param| {
                     let parameter_value = param.to_parameter_value(); // config default
-                    match profile_config {
-                        Some(profile_config) => profile_config
-                            .find_config_param(&parameter_value.name)
+                    match profile_script_parameters {
+                        Some(profile_script_parameters) => profile_script_parameters
+                            .get_parameter(&parameter_value.name)
                             .map(|profile_parameter| profile_parameter.to_parameter_value())
                             .unwrap_or_else(|| {
                                 debug!("Parameter {} is undefined. Using defaults from script manifest.", parameter_value.name);

--- a/eruption/src/plugins/sdk_support.rs
+++ b/eruption/src/plugins/sdk_support.rs
@@ -46,6 +46,7 @@ use crate::{
     hwdevices::RGBA,
     plugins::{self, Plugin},
     scripting::parameters,
+    scripting::parameters_util,
 };
 
 pub mod protocol {
@@ -571,7 +572,7 @@ impl SdkSupportPlugin {
                                                         value: map.1.to_string(),
                                                     })
                                                     .collect();
-                                                parameters::apply_parameters(
+                                                parameters_util::apply_parameters(
                                                     &message.profile_file,
                                                     &message.script_file,
                                                     &parameter_values,

--- a/eruption/src/plugins/sdk_support.rs
+++ b/eruption/src/plugins/sdk_support.rs
@@ -563,11 +563,11 @@ impl SdkSupportPlugin {
                                                 ),
                                             ) => {
                                                 let parameter_values: Vec<
-                                                    parameters::UntypedParameterValue,
+                                                    parameters::UntypedParameter,
                                                 > = message
                                                     .parameter_values
                                                     .iter()
-                                                    .map(|map| parameters::UntypedParameterValue {
+                                                    .map(|map| parameters::UntypedParameter {
                                                         name: map.0.to_string(),
                                                         value: map.1.to_string(),
                                                     })

--- a/eruption/src/scripting/parameters.rs
+++ b/eruption/src/scripting/parameters.rs
@@ -17,7 +17,11 @@
     Copyright (c) 2019-2022, The Eruption Development Team
 */
 
-use serde::{Deserialize, Serialize};
+use serde::{
+    de, ser::SerializeMap, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::collections::hash_map::{self, Entry};
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd)]
@@ -93,7 +97,7 @@ impl fmt::Display for TypedValue {
             TypedValue::Int(value) => write!(f, "{}", value),
             TypedValue::Float(value) => write!(f, "{}", value),
             TypedValue::Bool(value) => write!(f, "{}", value),
-            TypedValue::String(value) => write!(f, "{}", value),
+            TypedValue::String(value) => f.write_str(value),
             TypedValue::Color(value) => write!(f, "#{:06x}", value),
         }
     }
@@ -111,6 +115,7 @@ impl ManifestValue {
     }
 }
 
+#[allow(dead_code)]
 impl ManifestParameter {
     pub fn get_default(&self) -> TypedValue {
         self.manifest.get_default()
@@ -142,5 +147,306 @@ impl ToParameterValue for ManifestParameter {
             name: self.name.to_owned(),
             value: self.manifest.get_default(),
         }
+    }
+}
+
+// Parameter containers
+
+#[derive(Default, Deserialize, Clone, PartialEq)] // Serialize implemented below
+pub struct ManifestConfiguration(HashMap<String, ManifestParameter>);
+#[derive(Default, Deserialize, Clone, PartialEq)] // Serialize implemented below
+pub struct ProfileConfiguration(HashMap<String, ProfileScriptParameters>);
+#[derive(Default, Clone, PartialEq)] // Serialize and Deserialize implemented below
+pub struct ProfileScriptParameters(HashMap<String, ProfileParameter>);
+
+#[allow(dead_code)]
+impl ManifestConfiguration {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn set_parameter(&mut self, parameter: ManifestParameter) {
+        self.0.insert(parameter.name.to_owned(), parameter);
+    }
+
+    pub fn get_parameter(&self, parameter_name: &str) -> Option<&ManifestParameter> {
+        self.0.get(parameter_name)
+    }
+}
+
+impl fmt::Debug for ManifestConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[allow(dead_code)]
+impl ProfileConfiguration {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn set_parameter(&mut self, script_name: &str, parameter: ProfileParameter) {
+        let script_name = script_name.to_owned();
+        match self.0.entry(script_name) {
+            Entry::Occupied(mut o) => {
+                o.get_mut().set_parameter(parameter);
+            }
+            Entry::Vacant(v) => {
+                let mut parameters = ProfileScriptParameters::new();
+                parameters.set_parameter(parameter);
+                v.insert(parameters);
+            }
+        };
+        //self.get_parameters_mut(script_name).set_parameter(parameter);
+    }
+
+    pub fn get_parameters_mut(&mut self, script_name: &str) -> &mut ProfileScriptParameters {
+        //TODO(Ro): figure out how to do this using entry()
+        if !self.0.contains_key(script_name) {
+            let parameters = ProfileScriptParameters::new();
+            self.0.insert(script_name.to_owned(), parameters);
+        }
+        self.0.get_mut(script_name).unwrap()
+    }
+
+    pub fn get_parameter(
+        &self,
+        script_name: &str,
+        parameter_name: &str,
+    ) -> Option<&ProfileParameter> {
+        self.0.get(script_name)?.get_parameter(parameter_name)
+    }
+
+    pub fn get_parameter_mut(
+        &mut self,
+        script_name: &str,
+        parameter_name: &str,
+    ) -> Option<&mut ProfileParameter> {
+        self.0
+            .get_mut(script_name)?
+            .get_parameter_mut(parameter_name)
+    }
+
+    pub fn get_parameters(&self, script_name: &str) -> Option<&ProfileScriptParameters> {
+        self.0.get(script_name)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for ProfileConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<HashMap<String, ProfileScriptParameters>> for ProfileConfiguration {
+    fn from(map: HashMap<String, ProfileScriptParameters>) -> Self {
+        Self(map)
+    }
+}
+
+#[allow(dead_code)]
+impl ProfileScriptParameters {
+    fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn set_parameter(&mut self, parameter: ProfileParameter) {
+        self.0.insert(parameter.name.to_owned(), parameter);
+    }
+
+    pub fn get_parameter(&self, parameter_name: &str) -> Option<&ProfileParameter> {
+        self.0.get(parameter_name)
+    }
+
+    pub fn get_parameter_mut(&mut self, parameter_name: &str) -> Option<&mut ProfileParameter> {
+        self.0.get_mut(parameter_name)
+    }
+
+    pub fn iter(&self) -> hash_map::Values<String, ProfileParameter> {
+        self.0.values()
+    }
+}
+
+impl fmt::Debug for ProfileScriptParameters {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<const N: usize> From<[(String, ProfileScriptParameters); N]> for ProfileConfiguration {
+    fn from(arr: [(String, ProfileScriptParameters); N]) -> Self {
+        Self(HashMap::from(arr))
+    }
+}
+
+impl<const N: usize> From<[ProfileParameter; N]> for ProfileScriptParameters {
+    fn from(arr: [ProfileParameter; N]) -> Self {
+        Self(arr.into_iter().map(|p| (p.name.to_owned(), p)).collect())
+    }
+}
+
+/// Sorts by key (script name) before serializing
+impl Serialize for ManifestConfiguration {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+
+        let mut sorted = BTreeMap::new();
+        sorted.extend(&self.0);
+
+        for entry in sorted {
+            map.serialize_entry(entry.0, entry.1)?;
+        }
+        map.end()
+    }
+}
+
+/// Sorts by key (script name) before serializing
+impl Serialize for ProfileConfiguration {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+
+        let mut sorted = BTreeMap::new();
+        sorted.extend(&self.0);
+
+        for entry in sorted {
+            map.serialize_entry(entry.0, entry.1)?;
+        }
+        map.end()
+    }
+}
+
+// Serializes as a list.  The key is the parameter name which is also present in the parameter struct
+impl Serialize for ProfileScriptParameters {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+
+        let mut sorted = BTreeMap::new();
+        sorted.extend(&self.0);
+
+        for param in sorted.values() {
+            seq.serialize_element(param)?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ProfileScriptParameters {
+    fn deserialize<D>(deserializer: D) -> Result<ProfileScriptParameters, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(ProfileScriptParametersVisitor {})
+    }
+}
+
+struct ProfileScriptParametersVisitor;
+
+impl<'de> de::Visitor<'de> for ProfileScriptParametersVisitor {
+    type Value = ProfileScriptParameters;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("sequence of ProfileParameters")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut map = HashMap::with_capacity(seq.size_hint().unwrap_or(0));
+
+        while let Some(param) = seq.next_element::<ProfileParameter>()? {
+            map.insert(param.name.to_owned(), param);
+        }
+
+        Ok(ProfileScriptParameters(map))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use std::error::Error;
+
+    use super::{ProfileConfiguration, ProfileParameter, TypedValue};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestContainer {
+        config: ProfileConfiguration,
+    }
+
+    #[test]
+    fn profile_configuration_serialization_and_deserialization() -> Result<(), Box<dyn Error>> {
+        let test_container = TestContainer {
+            config: [
+                (
+                    "First Manifest".to_string(),
+                    [
+                        ProfileParameter {
+                            name: "parameter_one".to_string(),
+                            value: TypedValue::Bool(true),
+                            manifest: None,
+                        },
+                        ProfileParameter {
+                            name: "parameter_two".to_string(),
+                            value: TypedValue::Float(1.23),
+                            manifest: None,
+                        },
+                    ]
+                    .into(),
+                ),
+                (
+                    "Second Manifest".to_string(),
+                    [ProfileParameter {
+                        name: "abc".to_string(),
+                        value: TypedValue::Int(64),
+                        manifest: None,
+                    }]
+                    .into(),
+                ),
+            ]
+            .into(),
+        };
+
+        let toml = toml::ser::to_string(&test_container)?;
+        assert_eq!(
+            toml.trim(),
+            r#"
+[[config."First Manifest"]]
+name = "parameter_one"
+type = "bool"
+value = true
+
+[[config."First Manifest"]]
+name = "parameter_two"
+type = "float"
+value = 1.23
+
+[[config."Second Manifest"]]
+name = "abc"
+type = "int"
+value = 64
+        "#
+            .trim()
+        );
+
+        let de_test_container = toml::de::from_str::<TestContainer>(&toml)?;
+        println!("{}", toml);
+        assert_eq!(test_container, de_test_container);
+
+        Ok(())
     }
 }

--- a/eruption/src/scripting/parameters_util.rs
+++ b/eruption/src/scripting/parameters_util.rs
@@ -1,0 +1,119 @@
+/*
+    This file is part of Eruption.
+
+    Eruption is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Eruption is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Eruption.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright (c) 2019-2022, The Eruption Development Team
+*/
+
+use log::*;
+use same_file::is_same_file;
+use std::{path::PathBuf, sync::atomic::Ordering};
+
+use crate::{
+    profiles::{self, FindConfig},
+    script::{self},
+    scripting::manifest::{self, ParseConfig},
+    scripting::parameters::{ParameterValue, UntypedParameterValue},
+};
+
+pub type Result<T> = std::result::Result<T, eyre::Error>;
+
+pub fn apply_parameters(
+    profile_file: &str,
+    script_file: &str,
+    parameter_values: &[UntypedParameterValue],
+) -> Result<()> {
+    let profile_path = PathBuf::from(&profile_file);
+    let script_path = PathBuf::from(&script_file);
+
+    let manifest = manifest::Manifest::from(&script_path)?;
+    let manifest_config = manifest.config.unwrap_or_default();
+
+    // modify persistent profile state
+    match profiles::Profile::from(&profile_path) {
+        Ok(mut profile) => {
+            assert!(profile.config.is_some());
+
+            let profile_config = profile.config.as_mut().unwrap();
+            let profile_config = profile_config
+                .entry(manifest.name)
+                .or_insert_with(std::vec::Vec::new);
+
+            for parameter_value in parameter_values {
+                let manifest_param = manifest_config
+                    .parse_config_param(&parameter_value.name, &parameter_value.value)?;
+
+                if let Some(param) = profile_config
+                    .clone()
+                    .find_config_param(&parameter_value.name)
+                {
+                    // param already exists, remove the existing one first
+                    profile_config.retain(|elem| elem != param);
+                }
+
+                profile_config.push(manifest_param);
+            }
+            profile.save_params()?;
+        }
+
+        Err(e) => {
+            error!("Could not update profile state: {}", e);
+        }
+    }
+
+    let parameter_values: Vec<ParameterValue> = parameter_values
+        .iter()
+        .map(|pv| manifest_config.parse_config_param(&pv.name, &pv.value))
+        .filter_map(|pv| match pv {
+            Ok(pv) => Some(pv),
+            Err(e) => {
+                error!("Bad parameter: {}", e);
+                None
+            }
+        })
+        .map(|ppv| ParameterValue {
+            name: ppv.name.to_owned(),
+            value: ppv.value.to_owned(),
+        })
+        .collect();
+
+    let mut need_to_reload_profile = true;
+    {
+        if let Some(active_profile) = &*crate::ACTIVE_PROFILE.lock() {
+            if is_same_file(&active_profile.profile_file, &profile_path).unwrap_or(false) {
+                let lua_txs = crate::LUA_TXS.read();
+                let lua_tx = lua_txs
+                    .iter()
+                    .find(|&lua_tx| lua_tx.script_file == script_path);
+
+                if let Some(lua_tx) = lua_tx {
+                    let sent = lua_tx.send(script::Message::SetParameters { parameter_values });
+                    match sent {
+                        Ok(()) => need_to_reload_profile = false,
+                        Err(_) => {
+                            eprintln!("Could not update parameter from D-Bus request.");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if need_to_reload_profile {
+        crate::REQUEST_PROFILE_RELOAD.store(true, Ordering::SeqCst);
+    }
+
+    Ok(())
+}

--- a/eruption/src/scripting/parameters_util.rs
+++ b/eruption/src/scripting/parameters_util.rs
@@ -18,16 +18,38 @@
 */
 
 use log::*;
-use same_file::is_same_file;
-use std::{path::PathBuf, sync::atomic::Ordering};
+use same_file;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::Ordering;
 
 use crate::{
-    profiles, script,
-    scripting::manifest::{self, ParseConfig},
-    scripting::parameters::{PlainParameter, UntypedParameter},
+    profiles::Profile,
+    script,
+    scripting::manifest::Manifest,
+    scripting::parameters::{
+        ManifestParameter, ManifestValue, PlainParameter, ProfileParameter, ToPlainParameter,
+        TypedValue, UntypedParameter,
+    },
 };
 
+#[derive(Debug, thiserror::Error)]
+pub enum ParametersUtilError {
+    #[error("Could not open file for reading")]
+    OpenError {},
+
+    #[error("Could not parse parameter")]
+    ParseParameterError {},
+
+    #[error("Script manifest does not reference the parameter")]
+    NoSuchParameter {},
+}
+
 pub type Result<T> = std::result::Result<T, eyre::Error>;
+
+fn is_same_file(path1: &Path, path2: &Path) -> bool {
+    same_file::is_same_file(path1, path2).unwrap_or(false)
+}
 
 pub fn apply_parameters(
     profile_file: &str,
@@ -37,69 +59,140 @@ pub fn apply_parameters(
     let profile_path = PathBuf::from(&profile_file);
     let script_path = PathBuf::from(&script_file);
 
-    let manifest = manifest::Manifest::from(&script_path)?;
-    let manifest_config = manifest.config.unwrap_or_default();
+    // If the specified profile_file is for the active profile, update that directly.
+    {
+        let active_profile = &mut *crate::ACTIVE_PROFILE.lock();
+        if let Some(active_profile) = active_profile.as_mut() {
+            if is_same_file(&active_profile.profile_file, &profile_path) {
+                let new_parameters =
+                    update_profile_and_state_file(active_profile, &script_path, parameter_values)?;
+                drop(active_profile);
+                update_parameters_on_active_profile(&script_path, new_parameters)?;
+                return Ok(());
+            }
+        }
+    }
+
+    // Otherwise, load the profile and manifest files and modify that
+    let profile = Profile::load_file_and_state_only(&profile_path);
+    let mut profile = match profile {
+        Ok(profile) => profile,
+        Err(e) => {
+            error!("Could not open profile file: {}", e);
+            return Err(ParametersUtilError::OpenError {}.into());
+        }
+    };
+
+    let manifest = Manifest::load(&script_path);
+    let manifest = match manifest {
+        Ok(manifest) => manifest,
+        Err(e) => {
+            error!("Could not open manifest file: {}", e);
+            return Err(ParametersUtilError::OpenError {}.into());
+        }
+    };
+
+    profile.manifests.insert(manifest.name.to_owned(), manifest);
+
+    update_profile_and_state_file(&mut profile, &script_path, parameter_values)?;
+    Ok(())
+}
+
+fn update_profile_and_state_file(
+    profile: &mut Profile,
+    script_path: &Path,
+    parameter_values: &[UntypedParameter],
+) -> Result<Vec<PlainParameter>> {
+    let manifest = profile
+        .manifests
+        .values()
+        .find(|m| is_same_file(&m.script_file, &script_path));
+    let manifest = match manifest {
+        Some(manifest) => manifest,
+        None => {
+            error!("Manifest is not found in profile");
+            return Err(ParametersUtilError::OpenError {}.into());
+        }
+    };
+
+    let mut new_parameters: Vec<PlainParameter> = vec![];
 
     // modify persistent profile state
-    match profiles::Profile::from(&profile_path) {
-        Ok(mut profile) => {
-            let profile_script_parameter = profile.config.get_parameters_mut(&manifest.name);
+    let profile_script_parameter = profile.config.get_parameters_mut(&manifest.name);
 
-            for parameter_value in parameter_values {
-                let manifest_param = manifest_config
-                    .parse_config_param(&parameter_value.name, &parameter_value.value)?;
-
-                profile_script_parameter.set_parameter(manifest_param);
-            }
-            profile.save_params()?;
-        }
-
-        Err(e) => {
-            error!("Could not update profile state: {}", e);
-        }
-    }
-
-    let parameter_values: Vec<PlainParameter> = parameter_values
-        .iter()
-        .map(|pv| manifest_config.parse_config_param(&pv.name, &pv.value))
-        .filter_map(|pv| match pv {
-            Ok(pv) => Some(pv),
-            Err(e) => {
-                error!("Bad parameter: {}", e);
-                None
-            }
-        })
-        .map(|ppv| PlainParameter {
-            name: ppv.name.to_owned(),
-            value: ppv.value,
-        })
-        .collect();
-
-    let mut need_to_reload_profile = true;
-    {
-        if let Some(active_profile) = &*crate::ACTIVE_PROFILE.lock() {
-            if is_same_file(&active_profile.profile_file, &profile_path).unwrap_or(false) {
-                let lua_txs = crate::LUA_TXS.read();
-                let lua_tx = lua_txs
-                    .iter()
-                    .find(|&lua_tx| lua_tx.script_file == script_path);
-
-                if let Some(lua_tx) = lua_tx {
-                    let sent = lua_tx.send(script::Message::SetParameters { parameter_values });
-                    match sent {
-                        Ok(()) => need_to_reload_profile = false,
-                        Err(_) => {
-                            eprintln!("Could not update parameter from D-Bus request.");
-                        }
-                    }
+    for untyped_parameter in parameter_values {
+        let manifest_param = manifest.config.get_parameter(&untyped_parameter.name);
+        if let Some(manifest_param) = manifest_param {
+            match parse_new_profile_parameter(manifest_param, &untyped_parameter.value) {
+                Ok(profile_parameter) => {
+                    new_parameters.push(profile_parameter.to_plain_parameter());
+                    profile_script_parameter.set_parameter(profile_parameter);
+                }
+                Err(e) => {
+                    error!(
+                        "Could not parse {} value \"{}\": {}",
+                        manifest_param.name, untyped_parameter.value, e
+                    );
+                    return Err(ParametersUtilError::ParseParameterError {}.into());
                 }
             }
+        } else {
+            error!(
+                "Unknown configuration parameter \"{}\"",
+                untyped_parameter.name
+            );
+            return Err(ParametersUtilError::NoSuchParameter {}.into());
         }
     }
 
-    if need_to_reload_profile {
-        crate::REQUEST_PROFILE_RELOAD.store(true, Ordering::SeqCst);
+    profile.save_params()?;
+
+    Ok(new_parameters)
+}
+
+fn update_parameters_on_active_profile(
+    script_path: &Path,
+    parameter_values: Vec<PlainParameter>,
+) -> Result<()> {
+    let lua_txs = crate::LUA_TXS.read();
+    let lua_tx = lua_txs
+        .iter()
+        .find(|&lua_tx| is_same_file(&lua_tx.script_file, script_path));
+
+    if let Some(lua_tx) = lua_tx {
+        let sent = lua_tx.send(script::Message::SetParameters { parameter_values });
+        if let Err(e) = sent {
+            eprintln!("Could not update parameter from D-Bus request. {}", e);
+            crate::REQUEST_PROFILE_RELOAD.store(true, Ordering::SeqCst);
+        }
     }
 
     Ok(())
+}
+
+fn parse_new_profile_parameter(
+    manifest_parameter: &ManifestParameter,
+    val: &str,
+) -> std::result::Result<ProfileParameter, Box<dyn std::error::Error>> {
+    let typed_value = match &manifest_parameter.manifest {
+        ManifestValue::Int { .. } => TypedValue::Int(i64::from_str(val)?),
+        ManifestValue::Float { .. } => TypedValue::Float(f64::from_str(val)?),
+        ManifestValue::Bool { .. } => {
+            TypedValue::Bool(bool::from_str(&val.to_string().to_lowercase())?)
+        }
+        ManifestValue::String { .. } => TypedValue::String(val.to_owned()),
+        ManifestValue::Color { .. } => {
+            if &val[0..1] == "#" {
+                TypedValue::Color(u32::from_str_radix(&val[1..], 16)?)
+            } else {
+                TypedValue::Color(u32::from_str(val)?)
+            }
+        }
+    };
+
+    Ok(ProfileParameter {
+        name: manifest_parameter.name.to_owned(),
+        value: typed_value,
+        manifest: Some(manifest_parameter.manifest.to_owned()),
+    })
 }

--- a/eruption/src/scripting/parameters_util.rs
+++ b/eruption/src/scripting/parameters_util.rs
@@ -25,7 +25,7 @@ use crate::{
     profiles::{self, FindConfig},
     script::{self},
     scripting::manifest::{self, ParseConfig},
-    scripting::parameters::{ParameterValue, UntypedParameterValue},
+    scripting::parameters::{PlainParameter, UntypedParameter},
 };
 
 pub type Result<T> = std::result::Result<T, eyre::Error>;
@@ -33,7 +33,7 @@ pub type Result<T> = std::result::Result<T, eyre::Error>;
 pub fn apply_parameters(
     profile_file: &str,
     script_file: &str,
-    parameter_values: &[UntypedParameterValue],
+    parameter_values: &[UntypedParameter],
 ) -> Result<()> {
     let profile_path = PathBuf::from(&profile_file);
     let script_path = PathBuf::from(&script_file);
@@ -73,7 +73,7 @@ pub fn apply_parameters(
         }
     }
 
-    let parameter_values: Vec<ParameterValue> = parameter_values
+    let parameter_values: Vec<PlainParameter> = parameter_values
         .iter()
         .map(|pv| manifest_config.parse_config_param(&pv.name, &pv.value))
         .filter_map(|pv| match pv {
@@ -83,9 +83,9 @@ pub fn apply_parameters(
                 None
             }
         })
-        .map(|ppv| ParameterValue {
+        .map(|ppv| PlainParameter {
             name: ppv.name.to_owned(),
-            value: ppv.value.to_owned(),
+            value: ppv.value,
         })
         .collect();
 

--- a/eruption/src/threads.rs
+++ b/eruption/src/threads.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant};
 
 use crate::{
     constants, dbus_interface, hwdevices, macros, plugins, script,
-    scripting::parameters::ParameterValue, sdk_support, uleds, DeviceAction, EvdevError,
+    scripting::parameters::PlainParameter, sdk_support, uleds, DeviceAction, EvdevError,
     KeyboardDevice, MainError, MouseDevice, COLOR_MAPS_READY_CONDITION, FAILED_TXS, KEY_STATES,
     LUA_TXS, QUIT, REQUEST_FAILSAFE_MODE, RGBA, SDK_SUPPORT_ACTIVE, ULEDS_SUPPORT_ACTIVE,
 };
@@ -694,7 +694,7 @@ pub fn spawn_lua_thread(
     thread_idx: usize,
     lua_rx: Receiver<script::Message>,
     script_file: &Path,
-    parameter_values: &[ParameterValue],
+    parameters: &[PlainParameter],
 ) -> Result<()> {
     info!("Loading Lua script: {}", script_file.display());
 
@@ -705,7 +705,7 @@ pub fn spawn_lua_thread(
     ));
 
     let script_file = script_file.to_path_buf();
-    let mut parameter_values: HashMap<String, ParameterValue> = parameter_values
+    let mut parameter_values: HashMap<String, PlainParameter> = parameters
         .iter()
         .map(|pv| (pv.name.clone(), pv.clone()))
         .collect();

--- a/eruption/src/threads.rs
+++ b/eruption/src/threads.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant};
 
 use crate::{
     constants, dbus_interface, hwdevices, macros, plugins, script,
-    scripting::script::ParameterValue, sdk_support, uleds, DeviceAction, EvdevError,
+    scripting::parameters::ParameterValue, sdk_support, uleds, DeviceAction, EvdevError,
     KeyboardDevice, MainError, MouseDevice, COLOR_MAPS_READY_CONDITION, FAILED_TXS, KEY_STATES,
     LUA_TXS, QUIT, REQUEST_FAILSAFE_MODE, RGBA, SDK_SUPPORT_ACTIVE, ULEDS_SUPPORT_ACTIVE,
 };

--- a/eruptionctl/src/main.rs
+++ b/eruptionctl/src/main.rs
@@ -39,7 +39,6 @@ use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use rust_embed::RustEmbed;
 use same_file::is_same_file;
-use scripting::manifest::GetAttr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::{collections::HashMap, path::PathBuf};
@@ -1434,14 +1433,11 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
                     for script in &scripts {
                         if let Some(config_params) = script.config.as_ref() {
                             for config in config_params.iter() {
-                                // read param defaults
-                                let value = config.get_default();
-
                                 println!(
                                     "\"{}\" {} (default: {})",
                                     &script.name,
-                                    &config.get_name(),
-                                    &value,
+                                    &config.name,
+                                    &config.get_default(),
                                 );
                             }
                         }
@@ -1516,12 +1512,12 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
                         let what = script.config.unwrap_or_default();
                         let config_param = what
                             .iter()
-                            .find(|config_param| config_param.get_name() == &parameter);
+                            .find(|config_param| config_param.name == parameter);
                         match config_param {
                             Some(config_param) => println!(
                                 "\"{}\" {}; default: {}",
                                 &script.name,
-                                &config_param.get_name().bold(),
+                                &config_param.name.bold(),
                                 &config_param.get_default()
                             ),
                             None => println!("No parameter found."),
@@ -1535,7 +1531,7 @@ pub async fn async_main() -> std::result::Result<(), eyre::Error> {
                         println!(
                             "\"{}\" {}; default: {}",
                             &script.name,
-                            &param.get_name().bold(),
+                            &param.name.bold(),
                             &param.get_default()
                         );
                     }

--- a/eruptionctl/src/manifest.rs
+++ b/eruptionctl/src/manifest.rs
@@ -1,1 +1,0 @@
-../../eruption/src/scripting/manifest.rs

--- a/eruptionctl/src/scripting/manifest.rs
+++ b/eruptionctl/src/scripting/manifest.rs
@@ -1,0 +1,1 @@
+../../../eruption/src/scripting/manifest.rs

--- a/eruptionctl/src/scripting/mod.rs
+++ b/eruptionctl/src/scripting/mod.rs
@@ -17,9 +17,5 @@
     Copyright (c) 2019-2022, The Eruption Development Team
 */
 
-pub mod callbacks;
-pub mod constants;
 pub mod manifest;
 pub mod parameters;
-pub mod parameters_util;
-pub mod script;

--- a/eruptionctl/src/scripting/parameters.rs
+++ b/eruptionctl/src/scripting/parameters.rs
@@ -1,0 +1,1 @@
+../../../eruption/src/scripting/parameters.rs

--- a/eruptionctl/src/util.rs
+++ b/eruptionctl/src/util.rs
@@ -24,9 +24,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::constants;
-use crate::manifest::{self, Manifest, ManifestError};
 use crate::profiles;
 use crate::profiles::Profile;
+use crate::scripting::manifest::{self, Manifest, ManifestError};
 
 type Result<T> = std::result::Result<T, eyre::Error>;
 

--- a/eruptionctl/src/util.rs
+++ b/eruptionctl/src/util.rs
@@ -35,6 +35,16 @@ pub enum UtilError {
     #[error("File not found: {description}")]
     FileNotFound { description: String },
 
+    #[error("Read failed: {description}")]
+    FileReadError {
+        #[source]
+        source: std::io::Error,
+        description: String,
+    },
+
+    #[error("Not a file")]
+    NotAFile {},
+
     #[error("Profile error: {err}")]
     ProfileError { err: eyre::Error },
 }
@@ -131,8 +141,49 @@ pub fn get_manifest_for(script_file: &Path) -> PathBuf {
     manifest_path
 }
 
-pub fn is_file_accessible<P: AsRef<Path>>(p: P) -> std::io::Result<String> {
-    fs::read_to_string(p)
+pub fn demand_file_is_accessible<P: AsRef<Path>>(p: P) -> Result<()> {
+    // Does the path exist?
+    let path = match fs::canonicalize(p) {
+        Ok(path) => path,
+        Err(e) => {
+            return Err(UtilError::FileReadError {
+                source: e,
+                description: "Could not find file".to_owned(),
+            }
+            .into())
+        }
+    };
+
+    // Is the metadata readable?
+    let metadata = match fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(e) => {
+            return Err(UtilError::FileReadError {
+                source: e,
+                description: "Could not read metadata".to_owned(),
+            }
+            .into())
+        }
+    };
+
+    // Is the path a regular file?  (Symlinks will have been canonicalized to regular files.)
+    if !metadata.is_file() {
+        return Err(UtilError::NotAFile {}.into());
+    }
+
+    // Is the file readable?
+    match fs::File::open(&path) {
+        Err(e) => {
+            return Err(UtilError::FileReadError {
+                source: e,
+                description: "Could not open file".to_owned(),
+            }
+            .into())
+        }
+        _ => {}
+    };
+
+    Ok(())
 }
 
 pub fn edit_file<P: AsRef<Path>>(file_name: P) -> Result<()> {
@@ -148,7 +199,7 @@ pub fn edit_file<P: AsRef<Path>>(file_name: P) -> Result<()> {
 pub fn match_profile_by_name(profile_name: &str) -> Result<Profile> {
     let profile_path = PathBuf::from(&profile_name);
     if profile_path.is_file() {
-        match Profile::from(&profile_path) {
+        match Profile::load_file_and_state_only(&profile_path) {
             Ok(profile) => Ok(profile),
             Err(err) => Err(UtilError::ProfileError { err }.into()),
         }

--- a/support/tests/assets/manifest_test.lua
+++ b/support/tests/assets/manifest_test.lua
@@ -1,0 +1,20 @@
+-- This file is part of Eruption.
+--
+-- Eruption is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- Eruption is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with Eruption.  If not, see <http://www.gnu.org/licenses/>.
+--
+-- Copyright (c) 2019-2022, The Eruption Development Team
+
+function on_startup(config)
+    --
+end

--- a/support/tests/assets/manifest_test.lua.manifest
+++ b/support/tests/assets/manifest_test.lua.manifest
@@ -1,0 +1,32 @@
+#    This file is part of Eruption.
+#
+#    Eruption is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Eruption is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Eruption.  If not, see <http://www.gnu.org/licenses/>.
+#
+#    Copyright (c) 2019-2022, The Eruption Development Team
+
+
+name = "Manifest Test"
+description = "Test manifest load"
+version = "0.0.0"
+author = "The Eruption Development Team"
+min_supported_version = "0.0.12"
+tags = ['Demo']
+
+[[config]]
+type = 'int'
+name = 'some_integer'
+description = 'Integer to test'
+min = -1
+max = 9999
+default = 7

--- a/support/tests/assets/manifest_test.profile
+++ b/support/tests/assets/manifest_test.profile
@@ -1,0 +1,27 @@
+#    This file is part of Eruption.
+#
+#    Eruption is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Eruption is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Eruption.  If not, see <http://www.gnu.org/licenses/>.
+#
+#    Copyright (c) 2019-2022, The Eruption Development Team
+
+
+id = 'fed7112e-47fe-11ed-b57a-17c80b8f4a3f'
+name = 'Manifest Test'
+description = 'Test the full load of the manifest file'
+active_scripts = [ 'manifest_test.lua' ]
+
+[[config."Manifest Test"]]
+type = 'int'
+name = 'some_integer'
+value = 9876

--- a/support/tests/assets/with_state.profile
+++ b/support/tests/assets/with_state.profile
@@ -1,0 +1,29 @@
+#    This file is part of Eruption.
+#
+#    Eruption is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Eruption is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Eruption.  If not, see <http://www.gnu.org/licenses/>.
+#
+#    Copyright (c) 2019-2022, The Eruption Development Team
+
+
+id = '4038a868-47fe-11ed-8120-afe66707f14c'
+name = 'With State'
+description = 'This profile has an accompanying state file.'
+active_scripts = [
+    'solid.lua'
+]
+
+[[config."Solid Color"]]
+type = 'color'
+name = 'color_background'
+value = 0xff123456

--- a/support/tests/assets/with_state.profile.state
+++ b/support/tests/assets/with_state.profile.state
@@ -1,0 +1,10 @@
+{
+  "Solid Color": [
+    {
+      "type": "color",
+      "name": "color_background",
+      "value": 4284826401,
+      "default": 4294905872
+    }
+  ]
+}


### PR DESCRIPTION
This is another uncomfortably large refactor, this time targeting how parameters are handled as well as consolidating how Profiles and Manifests are loaded.  I hope you don't mind all the changes.
- The main benefit is that the code no longer has to iterate through parameter vecs to find to find them, nor match on parameter types to use them.  Both Profile and Manifest have parameter container structs with methods that do the work.
- No longer requiring matches to handle parameters cuts function sizes wherever they're used, sometimes significantly. 
- Profile's ::new() and ::from() have been replaced with ::load_file_only() and ::load_file_and_state_only().  Furthermore, ::load_fully() has also been added, which also loads the profile's manifests.  With that, code elsewhere is no longer required to spin through the profile's active_scripts and load the manifests itself to find and evaluate parameters.
- I've also added more tests to give confidence that the changes don't break serialization/deserialization.